### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "mysql": "^2.16.0",
     "node-correios": "^2.2.0",
     "nodemon": "^1.18.6",
-    "npm": "^6.9.0",
     "validar-cpf": "^2.1.1"
   }
 }


### PR DESCRIPTION

Hello lucaspedroso26!

It seems like you have npm as one of your (dev-) dependency in muse-shop.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
